### PR TITLE
Fixes issue #152 by using the meta file's line endings

### DIFF
--- a/Assets/RedBlueGames/MulliganRenamer/Editor/SpritesheetRenamer.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/SpritesheetRenamer.cs
@@ -132,17 +132,17 @@ namespace RedBlueGames.MulliganRenamer
 
         private static string ReplaceFileIDRecycleNames(string metafileText, string oldName, string newName)
         {
-            string fileIDPattern = "([\\d]{8}: )" + oldName + "\n";
+            string fileIDPattern = "([\\d]{8}: )" + oldName + "(\r?\n)";
             var fileIDRegex = new System.Text.RegularExpressions.Regex(fileIDPattern);
-            string replacementText = "$1" + newName + "\n";
+            string replacementText = "$1" + newName + "$2";
             return fileIDRegex.Replace(metafileText, replacementText);
         }
 
         private static string ReplaceSpriteData(string metafileText, string oldName, string newName)
         {
-            string spritenamePattern = "(name: )" + oldName + "\n";
+            string spritenamePattern = "(name: )" + oldName + "(\r?\n)";
             var spritenameRegex = new System.Text.RegularExpressions.Regex(spritenamePattern);
-            string replacementText = "$1" + newName + "\n";
+            string replacementText = "$1" + newName + "$2";
             return spritenameRegex.Replace(metafileText, replacementText);
         }
 


### PR DESCRIPTION
This should fix an issue where users with CRLF end of line characters
in their meta files could not rename sprites by finding and replacing
EOL characters based on either CRLF or just LF.