### PR TITLE
Removes Whitespace from Symbol matching in RemoveCharacters

### DIFF
--- a/Assets/RedBlueGames/MulliganRenamer/Editor/OperationDrawers/RemoveCharactersOperationDrawer.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/OperationDrawers/RemoveCharactersOperationDrawer.cs
@@ -6,29 +6,6 @@
 
     public class RemoveCharactersOperationDrawer : RenameOperationDrawer<RemoveCharactersOperation>
     {
-        public static readonly RemoveCharactersOperation.Configuration Symbols = new RemoveCharactersOperation.Configuration()
-        {
-            CharactersToRemove = "\\W",
-            CharactersAreRegex = true,
-            IsCaseSensitive = false
-        };
-
-        public static readonly RemoveCharactersOperation.Configuration Numbers = new RemoveCharactersOperation.Configuration()
-        {
-            CharactersToRemove = "\\d",
-            CharactersAreRegex = true,
-            IsCaseSensitive = false
-        };
-
-        private RemoveCharactersOperation.Configuration custom = new RemoveCharactersOperation.Configuration()
-        {
-            CharactersToRemove = string.Empty,
-            IsCaseSensitive = false,
-            CharactersAreRegex = false
-        };
-
-        private ReplaceStringOperation internalReplaceStringOperation;
-
         public RemoveCharactersOperationDrawer()
         {
             this.Initialize();
@@ -195,7 +172,7 @@
             {
                 DisplayName = "Symbols",
                 ReadOnlyLabel = "Removes special characters (ie. !@#$%^&*)",
-                Options = Symbols,
+                Options = RemoveCharactersOperation.Symbols,
                 IsReadOnly = true
             };
 
@@ -203,14 +180,18 @@
             {
                 DisplayName = "Numbers",
                 ReadOnlyLabel = "Removes digits 0-9",
-                Options = Numbers,
+                Options = RemoveCharactersOperation.Numbers,
                 IsReadOnly = true
             };
 
+            var customOptions = new RemoveCharactersOperation.Configuration();
+            customOptions.CharactersToRemove = string.Empty;
+            customOptions.IsCaseSensitive = false;
+            customOptions.CharactersAreRegex = false;
             var customPreset = new CharacterPresetGUI()
             {
                 DisplayName = "Custom",
-                Options = this.custom,
+                Options = customOptions,
                 IsReadOnly = false,
                 ReadOnlyLabel = string.Empty
             };

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/OperationDrawers/RemoveCharactersOperationDrawer.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/OperationDrawers/RemoveCharactersOperationDrawer.cs
@@ -184,6 +184,15 @@
                 IsReadOnly = true
             };
 
+            var whitespacePreset = new CharacterPresetGUI()
+            {
+                DisplayName = "Whitespace",
+                ReadOnlyLabel = "Removes whitespace",
+                Options = RemoveCharactersOperation.Whitespace,
+                IsReadOnly = true
+            };
+
+
             var customOptions = new RemoveCharactersOperation.Configuration();
             customOptions.CharactersToRemove = string.Empty;
             customOptions.IsCaseSensitive = false;
@@ -200,6 +209,7 @@
             {
                 symbolsPreset,
                 numbersPreset,
+                whitespacePreset,
                 customPreset
             };
         }

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/RemoveCharactersOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/RemoveCharactersOperation.cs
@@ -33,6 +33,20 @@ namespace RedBlueGames.MulliganRenamer
     /// </summary>
     public class RemoveCharactersOperation : IRenameOperation
     {
+        public static readonly RemoveCharactersOperation.Configuration Symbols = new RemoveCharactersOperation.Configuration()
+        {
+            CharactersToRemove = "^\\s\\w",
+            CharactersAreRegex = true,
+            IsCaseSensitive = false
+        };
+
+        public static readonly RemoveCharactersOperation.Configuration Numbers = new RemoveCharactersOperation.Configuration()
+        {
+            CharactersToRemove = "\\d",
+            CharactersAreRegex = true,
+            IsCaseSensitive = false
+        };
+
         private ReplaceStringOperation internalReplaceStringOperation;
 
         /// <summary>

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/RemoveCharactersOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/RemoveCharactersOperation.cs
@@ -47,6 +47,13 @@ namespace RedBlueGames.MulliganRenamer
             IsCaseSensitive = false
         };
 
+        public static readonly RemoveCharactersOperation.Configuration Whitespace = new RemoveCharactersOperation.Configuration()
+        {
+            CharactersToRemove = "\\s",
+            CharactersAreRegex = true,
+            IsCaseSensitive = false
+        };
+
         private ReplaceStringOperation internalReplaceStringOperation;
 
         /// <summary>

--- a/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/RemoveCharactersOpTests.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/RemoveCharactersOpTests.cs
@@ -116,19 +116,15 @@ namespace RedBlueGames.MulliganRenamer
         public void RemoveSymbols_StringHasWhitespaceAndSymbols_KeepsWhitespace()
         {
             // Arrange
-            var name = "A B ~[ ]?CD ";
+            var name = "!A !";
             var removeCharactersOp = new RemoveCharactersOperation();
             removeCharactersOp.Config = RemoveCharactersOperation.Symbols;
 
             var expected = new RenameResult()
             {
-                new Diff("A B ", DiffOperation.Equal),
-                new Diff("~", DiffOperation.Deletion),
-                new Diff("[", DiffOperation.Deletion),
-                new Diff(" ", DiffOperation.Equal),
-                new Diff("]", DiffOperation.Deletion),
-                new Diff("?", DiffOperation.Deletion),
-                new Diff("CD ", DiffOperation.Equal),
+                new Diff("!", DiffOperation.Deletion),
+                new Diff("A ", DiffOperation.Equal),
+                new Diff("!", DiffOperation.Deletion),
             };
 
             // Act
@@ -177,6 +173,50 @@ namespace RedBlueGames.MulliganRenamer
             var name = "1234567890";
             var removeCharactersOp = new RemoveCharactersOperation();
             removeCharactersOp.Config = RemoveCharactersOperation.Numbers;
+
+            var expected = new RenameResult();
+            for (int i = 0; i < name.Length; ++i)
+            {
+                var substring = name.Substring(i, 1);
+                expected.Add(new Diff(substring, DiffOperation.Deletion));
+            }
+
+            // Act
+            var result = removeCharactersOp.Rename(name, 0);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void RemoveWhitespace_LettersSymbolsAndWhitespaceInString_RemovesOnlyWhitespace()
+        {
+            // Arrange
+            var name = "A1! B";
+            var removeCharactersOp = new RemoveCharactersOperation();
+            removeCharactersOp.Config = RemoveCharactersOperation.Whitespace;
+
+            var expected = new RenameResult()
+            {
+                new Diff("A1!", DiffOperation.Equal),
+                new Diff(" ", DiffOperation.Deletion),
+                new Diff("B", DiffOperation.Equal),
+            };
+
+            // Act
+            var result = removeCharactersOp.Rename(name, 0);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void RemoveWhitespace_AllWhitespace_IsEmpty()
+        {
+            // Arrange
+            var name = "    ";
+            var removeCharactersOp = new RemoveCharactersOperation();
+            removeCharactersOp.Config = RemoveCharactersOperation.Whitespace;
 
             var expected = new RenameResult();
             for (int i = 0; i < name.Length; ++i)

--- a/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/RemoveCharactersOpTests.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/RemoveCharactersOpTests.cs
@@ -30,20 +30,6 @@ namespace RedBlueGames.MulliganRenamer
 
     public class RemoveCharactersOpTests
     {
-        public static readonly RemoveCharactersOperation.Configuration Symbols = new RemoveCharactersOperation.Configuration()
-        {
-            CharactersToRemove = "\\W",
-            CharactersAreRegex = true,
-            IsCaseSensitive = false
-        };
-
-        public static readonly RemoveCharactersOperation.Configuration Numbers = new RemoveCharactersOperation.Configuration()
-        {
-            CharactersToRemove = "\\d",
-            CharactersAreRegex = true,
-            IsCaseSensitive = false
-        };  
-
         [Test]
         public void RemoveCharacters_NullTarget_IsUnchanged()
         {
@@ -82,7 +68,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "A!@#$%BD*(";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = Symbols;
+            removeCharactersOp.Config = RemoveCharactersOperation.Symbols;
 
             var expected = new RenameResult()
             {
@@ -110,7 +96,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "`~!@#$%^&*()+-=[]{}\\|;:'\",<.>/?";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = Symbols;
+            removeCharactersOp.Config = RemoveCharactersOperation.Symbols;
 
             var expected = new RenameResult();
             for (int i = 0; i < name.Length; ++i)
@@ -127,12 +113,38 @@ namespace RedBlueGames.MulliganRenamer
         }
 
         [Test]
+        public void RemoveSymbols_StringHasWhitespaceAndSymbols_KeepsWhitespace()
+        {
+            // Arrange
+            var name = "A B ~[ ]?CD ";
+            var removeCharactersOp = new RemoveCharactersOperation();
+            removeCharactersOp.Config = RemoveCharactersOperation.Symbols;
+
+            var expected = new RenameResult()
+            {
+                new Diff("A B ", DiffOperation.Equal),
+                new Diff("~", DiffOperation.Deletion),
+                new Diff("[", DiffOperation.Deletion),
+                new Diff(" ", DiffOperation.Equal),
+                new Diff("]", DiffOperation.Deletion),
+                new Diff("?", DiffOperation.Deletion),
+                new Diff("CD ", DiffOperation.Equal),
+            };
+
+            // Act
+            var result = removeCharactersOp.Rename(name, 0);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
         public void RemoveNumbers_LettersAndNumbersInString_RemovesOnlyNumbers()
         {
             // Arrange
             var name = "A251B637k911p";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = Numbers;
+            removeCharactersOp.Config = RemoveCharactersOperation.Numbers;
 
             var expected = new RenameResult()
             {
@@ -164,7 +176,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "1234567890";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = Numbers;
+            removeCharactersOp.Config = RemoveCharactersOperation.Numbers;
 
             var expected = new RenameResult();
             for (int i = 0; i < name.Length; ++i)


### PR DESCRIPTION
This fixes #159 by taking out whitespace matching when RemovingCharacters -> Symbols. It also adds a selection so that users can deliberately delete whitespace.