### PR TITLE
Save and restore all RenameOperation properties, not just type

### DIFF
--- a/Assets/RedBlueGames/MulliganRenamer/Editor/OperationDrawers/AddStringSequenceOperationDrawer.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/OperationDrawers/AddStringSequenceOperationDrawer.cs
@@ -27,7 +27,7 @@ namespace RedBlueGames.MulliganRenamer
     using UnityEngine;
     using UnityEditor;
 
-    public class AddStringSequenceOperationDrawer : RenameOperationDrawer<CountByLetterOperation>
+    public class AddStringSequenceOperationDrawer : RenameOperationDrawer<AddStringSequenceOperation>
     {
         /// <summary>
         /// Gets the path that's displayed when this rename op is used in the Add Op menu.
@@ -108,7 +108,7 @@ namespace RedBlueGames.MulliganRenamer
                 this.RenameOperation.CountSequence);
             if (stringSequence != null)
             {
-                this.RenameOperation.CountSequence = stringSequence;
+                this.RenameOperation.SetCountSequence(stringSequence);
             }
 
             var prependRect = operationRect.GetSplitVertical(++currentRectSplit, numLines, LineSpacing);

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/AddStringOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/AddStringOperation.cs
@@ -29,8 +29,15 @@ namespace RedBlueGames.MulliganRenamer
     /// <summary>
     /// RenameOperation that adds a string to the rename string.
     /// </summary>
+    [System.Serializable]
     public class AddStringOperation : IRenameOperation
     {
+        [SerializeField]
+        private string prefix;
+
+        [SerializeField]
+        private string suffix;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AddStringOperation"/> class.
         /// </summary>
@@ -54,14 +61,34 @@ namespace RedBlueGames.MulliganRenamer
         /// <summary>
         /// Gets or sets the prefix to add.
         /// </summary>
-        /// <value>The prefix to add..</value>
-        public string Prefix { get; set; }
+        public string Prefix
+        {
+            get
+            {
+                return this.prefix;
+            }
+
+            set
+            {
+                this.prefix = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the suffix to add.
         /// </summary>
-        /// <value>The suffix to add.</value>
-        public string Suffix { get; set; }
+        public string Suffix
+        {
+            get
+            {
+                return this.suffix;
+            }
+
+            set
+            {
+                this.suffix = value;
+            }
+        }
 
         /// <summary>
         /// Clone this instance.

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/AddStringSequenceOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/AddStringSequenceOperation.cs
@@ -1,0 +1,60 @@
+﻿/* MIT License
+
+Copyright (c) 2016 Edward Rowe, RedBlueGames
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace RedBlueGames.MulliganRenamer
+{
+    using UnityEditor;
+    using UnityEngine;
+
+    /// <summary>
+    /// RenameOperation for adding a repeating sequence of strings. This is only necessary
+    /// because we don't serialize drawers, so in order to figure out which drawer
+    /// type corresponds with each operation, we have to make each drawer paired to a single
+    /// operation.
+    /// </summary>
+    [System.Serializable]
+    public class AddStringSequenceOperation : CountByLetterOperation
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:RedBlueGames.MulliganRenamer.AddStringSequenceOperation"/> class.
+        /// </summary>
+        public AddStringSequenceOperation() : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:RedBlueGames.MulliganRenamer.AddStringSequenceOperation"/> class.
+        /// This is a clone constructor, copying the values from one to another.
+        /// </summary>
+        /// <param name="operationToCopy">Operation to copy.</param>
+        public AddStringSequenceOperation(CountByLetterOperation operationToCopy) : base(operationToCopy) { }
+
+        /// <summary>
+        /// Clone this instance.
+        /// </summary>
+        /// <returns>A clone of this instance</returns>
+        public override IRenameOperation Clone()
+        {
+            var clone = new AddStringSequenceOperation(this);
+            return clone;
+        }
+    }
+}

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/AddStringSequenceOperation.cs.meta
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/AddStringSequenceOperation.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 89d663a56a88246a1b6d8d83ed38f095
+timeCreated: 1495391168
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/ChangeCaseOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/ChangeCaseOperation.cs
@@ -30,8 +30,12 @@ namespace RedBlueGames.MulliganRenamer
     /// <summary>
     /// RenameOperation that changes the case of the characters in the name.
     /// </summary>
+    [System.Serializable]
     public class ChangeCaseOperation : IRenameOperation
     {
+        [SerializeField]
+        private CasingChange casing;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ChangeCaseOperation"/> class.
         /// </summary>
@@ -69,7 +73,18 @@ namespace RedBlueGames.MulliganRenamer
         /// Gets or sets the desired casing.
         /// </summary>
         /// <value>The desired casing.</value>
-        public CasingChange Casing { get; set; }
+        public CasingChange Casing
+        {
+            get
+            {
+                return this.casing;
+            }
+
+            set
+            {
+                this.casing = value;
+            }
+        }
 
         public bool HasErrors()
         {

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/CountByLetterOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/CountByLetterOperation.cs
@@ -29,29 +29,56 @@ namespace RedBlueGames.MulliganRenamer
     /// <summary>
     /// Rename operation that counts using letters of the alphabet.
     /// </summary>
+    [System.Serializable]
     public class CountByLetterOperation : IRenameOperation
     {
-        public static readonly string[] UppercaseAlphabet = new string[]
+        private static readonly string[] UppercaseAlphabet = new string[]
         {
             "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O",
             "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
         };
 
-        public static readonly string[] LowercaseAlphabet = new string[]
+        private static readonly string[] LowercaseAlphabet = new string[]
         {
             "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o",
             "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
         };
+
+        [SerializeField]
+        private string[] countSequence;
+
+        [SerializeField]
+        private int startingCount;
+
+        [SerializeField]
+        private int increment;
+
+        [SerializeField]
+        private bool doNotCarryOver;
+
+        [SerializeField]
+        private bool prepend;
+
+        [SerializeField]
+        private StringPreset preset;
+
+        public enum StringPreset
+        {
+            Custom = 0,
+            LowercaseAlphabet = 1,
+            UppercaseAlphabet = 2
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:RedBlueGames.MulliganRenamer.CountByLetterOperation"/> class.
         /// </summary>
         public CountByLetterOperation()
         {
-            this.StartingCount = 0;
-            this.Increment = 1;
-            this.CountSequence = new string[0];
-            this.Prepend = false;
+            this.countSequence = new string[0];
+            this.startingCount = 0;
+            this.increment = 1;
+            this.doNotCarryOver = false;
+            this.prepend = false;
         }
 
         /// <summary>
@@ -64,40 +91,110 @@ namespace RedBlueGames.MulliganRenamer
             this.DoNotCarryOver = operationToCopy.DoNotCarryOver;
             this.StartingCount = operationToCopy.StartingCount;
             this.Increment = operationToCopy.Increment;
-            this.CountSequence = new string[operationToCopy.CountSequence.Length];
+            this.preset = operationToCopy.preset;
+            this.countSequence = new string[operationToCopy.CountSequence.Length];
+            operationToCopy.countSequence.CopyTo(this.countSequence, 0);
             this.Prepend = operationToCopy.Prepend;
-            operationToCopy.CountSequence.CopyTo(this.CountSequence, 0);
         }
 
         /// <summary>
         /// Gets or sets the count sequence, the sequence of strings to apply in order, corresponding
         /// with the count.
         /// </summary>
-        public string[] CountSequence { get; set; }
+        public string[] CountSequence
+        {
+            get
+            {
+                if (this.preset == StringPreset.LowercaseAlphabet)
+                {
+                    return LowercaseAlphabet;
+                }
+                else if (this.preset == StringPreset.UppercaseAlphabet)
+                {
+                    return UppercaseAlphabet;
+                }
+                else
+                {
+                    return this.countSequence;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the starting count which offsets all letter assignments.
         /// </summary>
-        public int StartingCount { get; set; }
+        public int StartingCount
+        {
+            get
+            {
+                return this.startingCount;
+            }
+
+            set
+            {
+                this.startingCount = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the increment to use when counting.
         /// </summary>
-        public int Increment { get; set; }
+        public int Increment
+        {
+            get
+            {
+                return this.increment;
+            }
+
+            set
+            {
+                this.increment = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether this
         /// <see cref="T:RedBlueGames.MulliganRenamer.CountByLetterOperation"/> should not carry
         /// over the sequence to another "digit".
         /// </summary>
-        public bool DoNotCarryOver { get; set; }
+        public bool DoNotCarryOver
+        {
+            get
+            {
+                return this.doNotCarryOver;
+            }
+
+            set
+            {
+                this.doNotCarryOver = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether this
         /// <see cref="T:RedBlueGames.MulliganRenamer.CountByLetterOperation"/> should prepend the count
         /// to the front of the string
         /// </summary>
-        public bool Prepend { get; set; }
+        public bool Prepend
+        {
+            get
+            {
+                return this.prepend;
+            }
+
+            set
+            {
+                this.prepend = value;
+            }
+        }
+
+        public StringPreset Preset
+        {
+            get
+            {
+                return this.preset;
+            }
+        }
 
         /// <summary>
         /// Checks if this RenameOperation has errors in its configuration.
@@ -112,7 +209,7 @@ namespace RedBlueGames.MulliganRenamer
         /// Clone this instance.
         /// </summary>
         /// <returns>A clone of this instance</returns>
-        public IRenameOperation Clone()
+        public virtual IRenameOperation Clone()
         {
             var clone = new CountByLetterOperation(this);
             return clone;
@@ -169,6 +266,25 @@ namespace RedBlueGames.MulliganRenamer
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Sets a custom string sequence to count from.
+        /// </summary>
+        /// <param name="sequence">Sequence of strings to count from</param>
+        public void SetCountSequence(string[] sequence)
+        {
+            this.preset = StringPreset.Custom;
+            this.countSequence = sequence;
+        }
+
+        /// <summary>
+        /// Sets a preset to use when counting.
+        /// </summary>
+        /// <param name="countPreset">Preset of strings to use when counting.</param>
+        public void SetCountSequencePreset(StringPreset countPreset)
+        {
+            this.preset = countPreset;
         }
     }
 }

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/EnumerateOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/EnumerateOperation.cs
@@ -30,8 +30,32 @@ namespace RedBlueGames.MulliganRenamer
     /// <summary>
     /// RenameOperation that enumerates characters onto the end of the rename string.
     /// </summary>
+    [System.Serializable]
     public class EnumerateOperation : IRenameOperation
     {
+        [SerializeField]
+        private int startingCount;
+
+        [SerializeField]
+        private string countFormat;
+
+        [SerializeField]
+        private int increment;
+
+        [SerializeField]
+        private bool prepend;
+
+        [SerializeField]
+        private CountFormatPreset formatPreset;
+
+        public enum CountFormatPreset
+        {
+            Custom = 0,
+            SingleDigit = 1,
+            LeadingZero = 2,
+            Underscore = 3,
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumerateOperation"/> class.
         /// </summary>
@@ -49,32 +73,97 @@ namespace RedBlueGames.MulliganRenamer
         {
             this.Initialize();
 
+            this.formatPreset = operationToCopy.formatPreset;
+            this.countFormat = operationToCopy.countFormat;
+
             this.StartingCount = operationToCopy.StartingCount;
-            this.CountFormat = operationToCopy.CountFormat;
             this.Increment = operationToCopy.Increment;
+            this.Prepend = operationToCopy.Prepend;
         }
 
         /// <summary>
         /// Gets or sets the starting count.
         /// </summary>
         /// <value>The starting count.</value>
-        public int StartingCount { get; set; }
+        public int StartingCount
+        {
+            get
+            {
+                return this.startingCount;
+            }
+
+            set
+            {
+                this.startingCount = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the format for the count, appended to the end of the string.
         /// </summary>
         /// <value>The count format.</value>
-        public string CountFormat { get; set; }
+        public string CountFormat
+        {
+            get
+            {
+                if (this.formatPreset == CountFormatPreset.SingleDigit)
+                {
+                    return "0";
+                }
+                else if (this.formatPreset == CountFormatPreset.LeadingZero)
+                {
+                    return "00";
+                }
+                else if (this.formatPreset == CountFormatPreset.Underscore)
+                {
+                    return "_00";
+                }
+                else
+                {
+                    return this.countFormat;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the increment to use when counting.
         /// </summary>
-        public int Increment { get; set; }
+        public int Increment
+        {
+            get
+            {
+                return this.increment;
+            }
+
+            set
+            {
+                this.increment = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not to add the count to the front of the string
         /// </summary>
-        public bool Prepend { get; set; }
+        public bool Prepend
+        {
+            get
+            {
+                return this.prepend;
+            }
+
+            set
+            {
+                this.prepend = value;
+            }
+        }
+
+        public CountFormatPreset FormatPreset
+        {
+            get
+            {
+                return this.formatPreset;
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating whether the count string format specified is parsable.
@@ -150,12 +239,36 @@ namespace RedBlueGames.MulliganRenamer
             return renameResult;
         }
 
+        /// <summary>
+        /// Sets a custom string format to use when counting.
+        /// </summary>
+        /// <param name="format">String format to use when counting</param>
+        public void SetCountFormat(string format)
+        {
+            this.countFormat = format;
+            this.formatPreset = CountFormatPreset.Custom;
+        }
+
+
+        /// <summary>
+        /// Sets a format preset to use when counting.
+        /// </summary>
+        /// <param name="preset">Preset format to use when counting.</param>
+        public void SetCountFormatPreset(CountFormatPreset preset)
+        {
+            this.formatPreset = preset;
+        }
+
         private void Initialize()
         {
             this.Increment = 1;
 
             // Give it an initially valid count format
-            this.CountFormat = "0";
+            this.countFormat = "0";
+
+            // Start in Single digit just because it's more readable and shows the user
+            // what to do.
+            this.formatPreset = CountFormatPreset.SingleDigit;
         }
     }
 }

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/ReplaceNameOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/ReplaceNameOperation.cs
@@ -50,11 +50,25 @@ namespace RedBlueGames.MulliganRenamer
             this.NewName = operationToCopy.NewName;
         }
 
+        [SerializeField]
+        private string newName;
+
         /// <summary>
         /// Gets or sets the new name.
         /// </summary>
         /// <value>The new name.</value>
-        public string NewName { get; set; }
+        public string NewName
+        {
+            get
+            {
+                return this.newName;
+            }
+
+            set
+            {
+                this.newName = value;
+            }
+        }
 
         public bool HasErrors()
         {

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/ReplaceStringOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/ReplaceStringOperation.cs
@@ -54,30 +54,86 @@ namespace RedBlueGames.MulliganRenamer
             this.CopyFrom(operationToCopy);
         }
 
+        [SerializeField]
+        private bool userRegex;
+
+        [SerializeField]
+        private string searchString;
+
+        [SerializeField]
+        private bool searchIsCaseSensitive;
+
+        [SerializeField]
+        private string replacementString;
+
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="ReplaceStringOperation"/>
         /// uses a regex expression for input.
         /// </summary>
         /// <value><c>true</c> if input is a regular expression; otherwise, <c>false</c>.</value>
-        public bool UseRegex { get; set; }
+        public bool UseRegex
+        {
+            get
+            {
+                return this.userRegex;
+            }
+
+            set
+            {
+                this.userRegex = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the search string that will be replaced.
         /// </summary>
         /// <value>The search string.</value>
-        public string SearchString { get; set; }
+        public string SearchString
+        {
+            get
+            {
+                return this.searchString;
+            }
+
+            set
+            {
+                this.searchString = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether the search is case sensitive.
         /// </summary>
         /// <value><c>true</c> if search is case sensitive; otherwise, <c>false</c>.</value>
-        public bool SearchIsCaseSensitive { get; set; }
+        public bool SearchIsCaseSensitive
+        {
+            get
+            {
+                return this.searchIsCaseSensitive;
+            }
+
+            set
+            {
+                this.searchIsCaseSensitive = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the replacement string, which replaces instances of the search token.
         /// </summary>
         /// <value>The replacement string.</value>
-        public string ReplacementString { get; set; }
+        public string ReplacementString
+        {
+            get
+            {
+                return this.replacementString;
+            }
+
+            set
+            {
+                this.replacementString = value;
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating whether this instance has errors that prevent it from Renaming.

--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/TrimCharactersOperation.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Operations/TrimCharactersOperation.cs
@@ -52,17 +52,45 @@ namespace RedBlueGames.MulliganRenamer
             this.NumBackDeleteChars = operationToCopy.NumBackDeleteChars;
         }
 
+        [SerializeField]
+        private int numFrontDeleteChars;
+
+        [SerializeField]
+        private int numBackDeleteChars;
+
         /// <summary>
         /// Gets or sets the number of characters to delete from the front.
         /// </summary>
         /// <value>The number front delete chars.</value>
-        public int NumFrontDeleteChars { get; set; }
+        public int NumFrontDeleteChars
+        {
+            get
+            {
+                return this.numFrontDeleteChars;
+            }
+
+            set
+            {
+                this.numFrontDeleteChars = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the number of characters to delete from the back.
         /// </summary>
         /// <value>The number back delete chars.</value>
-        public int NumBackDeleteChars { get; set; }
+        public int NumBackDeleteChars
+        {
+            get
+            {
+                return this.numBackDeleteChars;
+            }
+
+            set
+            {
+                this.numBackDeleteChars = value;
+            }
+        }
 
         public bool HasErrors()
         {

--- a/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/BulkRenamerTests.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/BulkRenamerTests.cs
@@ -221,11 +221,11 @@ namespace RedBlueGames.MulliganRenamer
             };
 
             var removeCharactersOp = new RemoveCharactersOperation();
-            var removeCharacterOptions = new RemoveCharactersOperation.Configuration();
+            var removeCharacterOptions = new RemoveCharactersOperation.RenameOptions();
             removeCharacterOptions.CharactersToRemove = "\\d";
             removeCharacterOptions.CharactersAreRegex = true;
             removeCharacterOptions.IsCaseSensitive = false;
-            removeCharactersOp.Config = removeCharacterOptions;
+            removeCharactersOp.SetOptions(removeCharacterOptions);
 
             var enumerateOp = new EnumerateOperation();
             enumerateOp.StartingCount = 1;
@@ -464,7 +464,7 @@ namespace RedBlueGames.MulliganRenamer
             spriteSheetConfig.UseZeroBasedIndexing = true;
             var textureWithSprites = this.SetupSpriteSheet(spriteSheetConfig);
             var removeNumbersOp = new RemoveCharactersOperation();
-            removeNumbersOp.Config = RemoveCharactersOperation.Numbers;
+            removeNumbersOp.SetOptionPreset(RemoveCharactersOperation.PresetID.Numbers);
             var enumerateOp = new EnumerateOperation();
             enumerateOp.StartingCount = 1;
             enumerateOp.Increment = 1;

--- a/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/CountByLetterOpTests.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/CountByLetterOpTests.cs
@@ -33,7 +33,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = null;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = new string[] { "A" };
+            countByLetterOp.SetCountSequence(new string[] { "A" });
 
             var expected = new RenameResult() { new Diff("A", DiffOperation.Insertion) };
 
@@ -66,7 +66,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
 
             var expected = new RenameResult() { new Diff("A", DiffOperation.Insertion) };
 
@@ -83,7 +83,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = "Something"; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
 
             var expected = new RenameResult() {
                 new Diff("Something", DiffOperation.Equal),
@@ -102,7 +102,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = "Something"; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
             countByLetterOp.Prepend = true;
 
             var expected = new RenameResult() {
@@ -122,7 +122,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
 
             var expected = new RenameResult() { new Diff("Z", DiffOperation.Insertion) };
 
@@ -139,7 +139,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
 
             var expected = new RenameResult() { new Diff("AA", DiffOperation.Insertion) };
 
@@ -156,7 +156,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
 
             var expected = new RenameResult() { new Diff("AB", DiffOperation.Insertion) };
 
@@ -173,7 +173,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
 
             var expected = new RenameResult() { new Diff("ZZ", DiffOperation.Insertion) };
 
@@ -190,7 +190,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
 
             var expected = new RenameResult() { new Diff("AAA", DiffOperation.Insertion) };
 
@@ -207,7 +207,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
 
             // Act / Assert
             for (int i = 0; i < 25; ++i)
@@ -225,7 +225,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.LowercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.LowercaseAlphabet);
 
             // Act / Assert
             for (int i = 0; i < 25; ++i)
@@ -243,7 +243,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
             countByLetterOp.StartingCount = 1;
 
             var expected = new RenameResult() { new Diff("B", DiffOperation.Insertion) };
@@ -261,7 +261,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
             countByLetterOp.StartingCount = 25;
 
             var expected = new RenameResult() { new Diff("AA", DiffOperation.Insertion) };
@@ -279,7 +279,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = CountByLetterOperation.UppercaseAlphabet;
+            countByLetterOp.SetCountSequencePreset(CountByLetterOperation.StringPreset.UppercaseAlphabet);
             countByLetterOp.StartingCount = 53;
 
             var expected = new RenameResult() { new Diff("BC", DiffOperation.Insertion) };
@@ -297,7 +297,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = new string[] { "X", "Y", "Z" };
+            countByLetterOp.SetCountSequence(new string[] { "X", "Y", "Z" });
             countByLetterOp.DoNotCarryOver = true;
 
             var expected = new RenameResult() { new Diff("X", DiffOperation.Insertion) };
@@ -315,7 +315,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = string.Empty; ;
             var countByLetterOp = new CountByLetterOperation();
-            countByLetterOp.CountSequence = new string[] { "X", "Y", "Z" };
+            countByLetterOp.SetCountSequence(new string[] { "X", "Y", "Z" });
             countByLetterOp.Increment = 2;
 
             var expected = new RenameResult() { new Diff("XY", DiffOperation.Insertion) };

--- a/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/EnumerateOpTests.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/EnumerateOpTests.cs
@@ -36,7 +36,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             string name = null;
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = "0";
+            enumerateOp.SetCountFormat("0");
             enumerateOp.StartingCount = 0;
 
             var expected = new RenameResult() { new Diff("0", DiffOperation.Insertion) };
@@ -54,7 +54,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "Char_Hero";
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = string.Empty;
+            enumerateOp.SetCountFormat(string.Empty);
 
             var expected = new RenameResult() { new Diff(name, DiffOperation.Equal) };
 
@@ -71,7 +71,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "Char_Hero";
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = "0";
+            enumerateOp.SetCountFormat("0");
             enumerateOp.StartingCount = 0;
 
             var expected = new RenameResult()
@@ -93,7 +93,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "Char_Hero";
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = "0";
+            enumerateOp.SetCountFormat("0");
             enumerateOp.StartingCount = 0;
             enumerateOp.Prepend = true;
 
@@ -123,7 +123,7 @@ namespace RedBlueGames.MulliganRenamer
                 "BlockE",
             };
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = "0";
+            enumerateOp.SetCountFormat("0");
             enumerateOp.StartingCount = 1;
 
             var expectedRenameResults = new RenameResult[]
@@ -160,7 +160,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "Char_Hero";
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = "0";
+            enumerateOp.SetCountFormat("0");
             enumerateOp.StartingCount = -1;
 
 
@@ -183,7 +183,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "Char_Hero";
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = "s";
+            enumerateOp.SetCountFormat("s");
             enumerateOp.StartingCount = 100;
 
             var expected = new RenameResult() { new Diff(name, DiffOperation.Equal) };
@@ -207,7 +207,7 @@ namespace RedBlueGames.MulliganRenamer
             };
 
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = "0";
+            enumerateOp.SetCountFormat("0");
             enumerateOp.StartingCount = 1;
             enumerateOp.Increment = 2;
 
@@ -249,7 +249,7 @@ namespace RedBlueGames.MulliganRenamer
             };
 
             var enumerateOp = new EnumerateOperation();
-            enumerateOp.CountFormat = "0";
+            enumerateOp.SetCountFormat("0");
             enumerateOp.StartingCount = 1;
             enumerateOp.Increment = -1;
 

--- a/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/RemoveCharactersOpTests.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Tests/Editor/RemoveCharactersOpTests.cs
@@ -68,7 +68,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "A!@#$%BD*(";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = RemoveCharactersOperation.Symbols;
+            removeCharactersOp.SetOptionPreset(RemoveCharactersOperation.PresetID.Symbols);
 
             var expected = new RenameResult()
             {
@@ -96,7 +96,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "`~!@#$%^&*()+-=[]{}\\|;:'\",<.>/?";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = RemoveCharactersOperation.Symbols;
+            removeCharactersOp.SetOptionPreset(RemoveCharactersOperation.PresetID.Symbols);
 
             var expected = new RenameResult();
             for (int i = 0; i < name.Length; ++i)
@@ -118,7 +118,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "!A !";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = RemoveCharactersOperation.Symbols;
+            removeCharactersOp.SetOptionPreset(RemoveCharactersOperation.PresetID.Symbols);
 
             var expected = new RenameResult()
             {
@@ -140,7 +140,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "A251B637k911p";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = RemoveCharactersOperation.Numbers;
+            removeCharactersOp.SetOptionPreset(RemoveCharactersOperation.PresetID.Numbers);
 
             var expected = new RenameResult()
             {
@@ -172,7 +172,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "1234567890";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = RemoveCharactersOperation.Numbers;
+            removeCharactersOp.SetOptionPreset(RemoveCharactersOperation.PresetID.Numbers);
 
             var expected = new RenameResult();
             for (int i = 0; i < name.Length; ++i)
@@ -194,7 +194,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "A1! B";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = RemoveCharactersOperation.Whitespace;
+            removeCharactersOp.SetOptionPreset(RemoveCharactersOperation.PresetID.Whitespace);
 
             var expected = new RenameResult()
             {
@@ -216,7 +216,7 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "    ";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = RemoveCharactersOperation.Whitespace;
+            removeCharactersOp.SetOptionPreset(RemoveCharactersOperation.PresetID.Whitespace);
 
             var expected = new RenameResult();
             for (int i = 0; i < name.Length; ++i)
@@ -238,10 +238,12 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "abz35!450k";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = new RemoveCharactersOperation.Configuration()
+            var customOptions = new RemoveCharactersOperation.RenameOptions()
             {
                 CharactersToRemove = "ak!5"
             };
+
+            removeCharactersOp.SetOptions(customOptions);
 
             var expected = new RenameResult()
             {
@@ -268,11 +270,13 @@ namespace RedBlueGames.MulliganRenamer
             // Arrange
             var name = "ABCDabcdD";
             var removeCharactersOp = new RemoveCharactersOperation();
-            removeCharactersOp.Config = new RemoveCharactersOperation.Configuration()
+            var customOptions = new RemoveCharactersOperation.RenameOptions()
             {
                 CharactersToRemove = "ABCD",
                 IsCaseSensitive = true
             };
+
+            removeCharactersOp.SetOptions(customOptions);
 
             var expected = new RenameResult()
             {


### PR DESCRIPTION
This makes RenameOperationSequence serializable. It required moving
some of the GUI code (preset values) into the models, so that they
could be easily serialized. The difficult ones were AddStringSequence,
RemoveCharacters, Enumerate (now called Count), and ChangeCase.