### PR TITLE
Switched min #if version to 6.4 to avoid obsolete warnings

### DIFF
--- a/Assets/RedBlueGames/MulliganRenamer/Editor/Renaming/BulkRenamer.cs
+++ b/Assets/RedBlueGames/MulliganRenamer/Editor/Renaming/BulkRenamer.cs
@@ -103,7 +103,7 @@ namespace RedBlueGames.MulliganRenamer
                     // Decrement progress bar count because we'll increment it later when we do the deferred objects.
                     --progressBarStep;
                     deferredRenames.Add(assetToRename);
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                     newName = assetToRename.NamedObject.GetEntityId().ToString();
 #else
                     newName = assetToRename.NamedObject.GetInstanceID().ToString();


### PR DESCRIPTION
I initially used 6.5 or newer, but after doing more research, I realized that `GetInstanceID()` was marked as obsolete back in 6.4.
Afaik, it wasn't throwing any errors there, just warnings, but better to avoid that too.
https://docs.unity3d.com/6000.4/Documentation/ScriptReference/Object.GetInstanceID.html